### PR TITLE
Enumerated boolean literals

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt::Display, str::FromStr};
 
 use nom::{
     branch::alt,
-    bytes::complete::{escaped, tag, tag_no_case, take_while, take_while1},
+    bytes::complete::{escaped, tag, take_while, take_while1},
     character::complete::{alpha1, alphanumeric1, digit0, digit1, none_of},
     combinator::{all_consuming, cut, map, opt, recognize},
     error::Error,
@@ -312,10 +312,12 @@ fn string_literal(input: &str) -> IResult<&str, CypherValue> {
 }
 
 fn boolean_literal(input: &str) -> IResult<&str, CypherValue> {
-  alt((
-      map(tag_no_case("false"), |_| CypherValue::Boolean(false)),
-      map(tag_no_case("true"),  |_| CypherValue::Boolean(true))
-  ))(input)
+    alt((
+        map(tag("true"),  |_| CypherValue::Boolean(true)),
+        map(tag("TRUE"),  |_| CypherValue::Boolean(true)),
+        map(tag("false"), |_| CypherValue::Boolean(false)),
+        map(tag("FALSE"), |_| CypherValue::Boolean(false))
+    ))(input)
 }
 
 fn cypher_value(input: &str) -> IResult<&str, CypherValue> {
@@ -596,7 +598,7 @@ mod tests {
     #[test_case("\"\"",           CypherValue::from("")             ; "dq string: empty")]
     #[test_case(r#""foobar\"s""#, CypherValue::from(r#"foobar\"s"#) ; "dq string: escaped")]
     #[test_case("true",           CypherValue::from(true)  ; "bool: true")]
-    #[test_case("false",          CypherValue::from(false) ; "bool: false")]
+    #[test_case("FALSE",          CypherValue::from(false) ; "bool: false")]
     fn cypher_value(input: &str, expected: CypherValue) {
         assert_eq!(input.parse(), Ok(expected))
     }


### PR DESCRIPTION
I've read your GDL spec for boolean literals here:
[https://github.com/s1ck/gdl/blob/master/src/main/antlr4/org/s1ck/gdl/GDL.g4#L151](url)
and I think it would be right to implement same restrictions.
